### PR TITLE
Fix SCIM_DEBUG_AllMask to be unisgned

### DIFF
--- a/src/scim_debug.h
+++ b/src/scim_debug.h
@@ -41,7 +41,7 @@ namespace scim {
  * @name The mask for debug messages filtering.
  * @{
  */
-#define SCIM_DEBUG_AllMask          (~0) /**< Show all messages. */
+#define SCIM_DEBUG_AllMask          ((uint32)~0) /**< Show all messages. */
 #define SCIM_DEBUG_MainMask         1    /**< Show messages of main application. */
 #define SCIM_DEBUG_ConfigMask       2    /**< Show messages of Config objects */
 #define SCIM_DEBUG_IMEngineMask     4    /**< Show messages of IMEngine objects */


### PR DESCRIPTION
When compiling with C++11
```
.././../../../src/scim_debug.cpp:53:1: error: narrowing conversion of ‘-1’ from ‘int’ to ‘scim::uint32 {aka unsigned int}’ inside { } [-Wnarrowing]
```

this PR fixes that by casting to unsigned int.