### PR TITLE
build: Fix undefined X11 references.

### DIFF
--- a/extras/immodules/client-gtk/gtk2/Makefile.am
+++ b/extras/immodules/client-gtk/gtk2/Makefile.am
@@ -40,11 +40,12 @@ im_scim_la_CFLAGS  =@GTK2_CFLAGS@
 
 im_scim_la_LDFLAGS = -rpath $(moduledir) \
 		     -avoid-version -no-undefined \
-		     -module \
-		     @GTK2_LIBS@
+		     -module
 
 im_scim_la_LIBADD  = $(top_builddir)/extras/immodules/common/libscimbridgecommon.la \
-					$(top_builddir)/extras/immodules/client-common/libscimbridgeclientcommon.la
+		     $(top_builddir)/extras/immodules/client-common/libscimbridgeclientcommon.la \
+		     @X_LIBS@ \
+		     @GTK2_LIBS@
 
 endif
 

--- a/extras/immodules/client-gtk/gtk3/Makefile.am
+++ b/extras/immodules/client-gtk/gtk3/Makefile.am
@@ -40,11 +40,12 @@ im_scim_la_CFLAGS  =@GTK3_CFLAGS@
 
 im_scim_la_LDFLAGS = -rpath $(moduledir) \
 		     -avoid-version -no-undefined \
-		     -module \
-		     @GTK3_LIBS@
+		     -module
 
 im_scim_la_LIBADD  = $(top_builddir)/extras/immodules/common/libscimbridgecommon.la \
-					$(top_builddir)/extras/immodules/client-common/libscimbridgeclientcommon.la
+		     $(top_builddir)/extras/immodules/client-common/libscimbridgeclientcommon.la \
+		     @X_LIBS@ \
+		     @GTK3_LIBS@
 
 endif
 


### PR DESCRIPTION
When building scim with slibtool (https://dev.midipix.org/cross/slibtool) the build fails with undefined X11 references.
```
rdlibtool --tag=CC --mode=link gcc -I/usr/include/gtk-2.0 -I/usr/lib64/gtk-2.0/include -I/usr/include/pango-1.0 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/lib64/libffi/include -I/usr/include/fribidi -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/uuid -I/usr/include/libpng16 -I/usr/include/harfbuzz -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/atk-1.0 -pthread -g -O2 -rpath /usr/lib64/gtk-2.0/2.10.0/immodules -avoid-version -no-undefined -module -lgtk-x11-2.0 -lgdk-x11-2.0 -lpangocairo-1.0 -latk-1.0 -lcairo -lgio-2.0 -lpangoft2-1.0 -lfontconfig -lfreetype -lpango-1.0 -lgdk_pixbuf-2.0 -lgobject-2.0 -lglib-2.0 -o im-scim.la -rpath /usr/lib64/gtk-2.0/2.10.0/immodules im_scim_la-im-scim-bridge-gtk.lo im_scim_la-scim-bridge-client-gtk.lo im_scim_la-scim-bridge-client-imcontext-gtk.lo im_scim_la-scim-bridge-client-key-event-utility-gtk.lo ../../../../extras/immodules/common/libscimbridgecommon.la ../../../../extras/immodules/client-common/libscimbridgeclientcommon.la

rdlibtool: lconf: {.name="libtool"}.
rdlibtool: fdcwd: {.fdcwd=AT_FDCWD, .realpath="/tmp/scim/extras/immodules/client-gtk/gtk2"}.
rdlibtool: lconf: fstatat(AT_FDCWD,".",...) = 0 {.st_dev = 45, .st_ino = 13106}.
rdlibtool: lconf: openat(AT_FDCWD,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(AT_FDCWD,"../",O_DIRECTORY,0) = 3.
rdlibtool: lconf: fstat(3,...) = 0 {.st_dev = 45, .st_ino = 13105}.
rdlibtool: lconf: openat(3,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(3,"../",O_DIRECTORY,0) = 4.
rdlibtool: lconf: fstat(4,...) = 0 {.st_dev = 45, .st_ino = 13057}.
rdlibtool: lconf: openat(4,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(4,"../",O_DIRECTORY,0) = 3.
rdlibtool: lconf: fstat(3,...) = 0 {.st_dev = 45, .st_ino = 13046}.
rdlibtool: lconf: openat(3,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(3,"../",O_DIRECTORY,0) = 4.
rdlibtool: lconf: fstat(4,...) = 0 {.st_dev = 45, .st_ino = 12914}.
rdlibtool: lconf: openat(4,"libtool",O_RDONLY,0) = 3.
rdlibtool: lconf: found "/tmp/scim/libtool".
rdlibtool: link: x86_64-pc-linux-gnu-ar crs .libs/im-scim.a .libs/im_scim_la-im-scim-bridge-gtk.o .libs/im_scim_la-scim-bridge-client-gtk.o .libs/im_scim_la-scim-bridge-client-imcontext-gtk.o .libs/im_scim_la-scim-bridge-client-key-event-utility-gtk.o
rdlibtool: link: gcc .libs/im_scim_la-im-scim-bridge-gtk.o .libs/im_scim_la-scim-bridge-client-gtk.o .libs/im_scim_la-scim-bridge-client-imcontext-gtk.o .libs/im_scim_la-scim-bridge-client-key-event-utility-gtk.o -Wl,--whole-archive ../../../../extras/immodules/common/.libs/libscimbridgecommon.a -Wl,--no-whole-archive -Wl,--whole-archive ../../../../extras/immodules/client-common/.libs/libscimbridgeclientcommon.a -Wl,--no-whole-archive -I/usr/include/gtk-2.0 -I/usr/lib64/gtk-2.0/include -I/usr/include/pango-1.0 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/lib64/libffi/include -I/usr/include/fribidi -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/uuid -I/usr/include/libpng16 -I/usr/include/harfbuzz -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/atk-1.0 -pthread -g -O2 -lgtk-x11-2.0 -lgdk-x11-2.0 -lpangocairo-1.0 -latk-1.0 -lcairo -lgio-2.0 -lpangoft2-1.0 -lfontconfig -lfreetype -lpango-1.0 -lgdk_pixbuf-2.0 -lgobject-2.0 -lglib-2.0 -shared -fPIC -Wl,--no-undefined -o .libs/im-scim.so
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: .libs/im_scim_la-scim-bridge-client-key-event-utility-gtk.o: in function `scim_bridge_key_event_gdk_to_bridge':
/tmp/scim/extras/immodules/client-gtk/gtk2/../scim-bridge-client-key-event-utility-gtk.c:131: undefined reference to `XGetKeyboardMapping'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/scim/extras/immodules/client-gtk/gtk2/../scim-bridge-client-key-event-utility-gtk.c:134: undefined reference to `XFree'
collect2: error: ld returned 1 exit status
rdlibtool: exec error upon slbt_exec_link_create_library(), line 1446: (see child process error messages).
rdlibtool: < returned to > slbt_exec_link(), line 1843.
make[4]: *** [Makefile:588: im-scim.la] Error 2
make[4]: Leaving directory '/tmp/scim/extras/immodules/client-gtk/gtk2'
make[3]: *** [Makefile:517: all-recursive] Error 1
make[3]: Leaving directory '/tmp/scim/extras/immodules'
make[2]: *** [Makefile:499: all-recursive] Error 1
make[2]: Leaving directory '/tmp/scim/extras'
make[1]: *** [Makefile:640: all-recursive] Error 1
make[1]: Leaving directory '/tmp/scim'
make: *** [Makefile:543: all] Error 2
```
This doesn't happen with GNU libtool because these `Makefile.am` files contain `-no-undefined` which libtool silently filters out while slibtool does not. It can be easily fixed by including `X_LIBS` where needed.

Note: I did not test the qt3 or qt4 code paths which I do not have the dependencies for.

Also see this downstream issue: https://bugs.gentoo.org/777297