### PR TITLE
extras/panel/scim_panel_gtk.cpp: fix build with clang19

### DIFF
--- a/extras/panel/scim_panel_gtk.cpp
+++ b/extras/panel/scim_panel_gtk.cpp
@@ -2560,10 +2560,10 @@ create_pango_attrlist (const String        &mbs,
     guint wlen = g_utf8_strlen (mbs.c_str (), mbs.length ());
 
 #if GTK_CHECK_VERSION(3, 0, 0)
-    guint16 _normal_bg_rgb[] = { 65536*_normal_bg.red, 65536*_normal_bg.green, 65536*_normal_bg.blue };
-    guint16 _active_bg_rgb[] = { 65536*_active_bg.red, 65536*_active_bg.green, 65536*_active_bg.blue };
-    guint16 _normal_text_rgb[] = { 65536*_normal_text.red, 65536*_normal_text.green, 65536*_normal_text.blue };
-    guint16 _active_text_rgb[] = { 65536*_active_text.red, 65536*_active_text.green, 65536*_active_text.blue };
+    guint16 _normal_bg_rgb[] = { (guint16)(65536*_normal_bg.red), (guint16)(65536*_normal_bg.green), (guint16)(65536*_normal_bg.blue) };
+    guint16 _active_bg_rgb[] = { (guint16)(65536*_active_bg.red), (guint16)(65536*_active_bg.green), (guint16)(65536*_active_bg.blue) };
+    guint16 _normal_text_rgb[] = { (guint16)(65536*_normal_text.red), (guint16)(65536*_normal_text.green), (guint16)(65536*_normal_text.blue) };
+    guint16 _active_text_rgb[] = { (guint16)(65536*_active_text.red), (guint16)(65536*_active_text.green), (guint16)(65536*_active_text.blue) };
 #else
     guint16 _normal_bg_rgb[] = { _normal_bg.red, _normal_bg.green, _normal_bg.blue };
     guint16 _active_bg_rgb[] = { _active_bg.red, _active_bg.green, _active_bg.blue };

--- a/modules/FrontEnd/IMdkit/Xi18n.h
+++ b/modules/FrontEnd/IMdkit/Xi18n.h
@@ -69,12 +69,18 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #define I18N_SET	1
 #define I18N_GET	2
 
-typedef struct
+typedef struct _Xi18nCore *Xi18n;
+struct _TransportSW;
+typedef struct _TransportSW TransportSW;
+
+typedef Bool (*CheckAddrFunc)(Xi18n i18n_core, TransportSW *transSW, char *address);
+
+struct _TransportSW
 {
     char        *transportname;
     int         namelen;
-    Bool        (*checkAddr) ();
-} TransportSW;
+    CheckAddrFunc checkAddr;
+};
 
 typedef struct _XIMPending
 {
@@ -167,8 +173,6 @@ typedef struct _Xi18nClient
     void *trans_rec;		/* contains transport specific data  */
     struct _Xi18nClient *next;
 } Xi18nClient;
-
-typedef struct _Xi18nCore *Xi18n;
 
 /*
  * Callback Struct for XIM Protocol

--- a/modules/FrontEnd/IMdkit/i18nMethod.c
+++ b/modules/FrontEnd/IMdkit/i18nMethod.c
@@ -89,7 +89,7 @@ TransportSW _TransR[] =
 #ifdef DNETCONN
     {"decnet",          6, _Xi18nCheckTransAddress},
 #endif
-    {(char *) NULL,     0, (Bool (*) ()) NULL}
+    {(char *) NULL,     0, (CheckAddrFunc) NULL}
 };
 
 static Bool GetInputStyles (Xi18n i18n_core, XIMStyles **p_style)


### PR DESCRIPTION
clang 19 report:

  error: type 'gdouble' (aka 'double') cannot be narrowed to 'guint16' (aka 'unsigned short') in initializer list