### PR TITLE
Daemonize the GTK panel before starting threads

### DIFF
--- a/extras/panel/scim_panel_gtk.cpp
+++ b/extras/panel/scim_panel_gtk.cpp
@@ -4286,6 +4286,9 @@ int main (int argc, char *argv [])
         return -1;
     }
 
+    if (daemon)
+        scim_daemon ();
+
 #if !GTK_CHECK_VERSION(2, 32, 0)
     /* init threads */
     g_thread_init (NULL);
@@ -4317,9 +4320,6 @@ int main (int argc, char *argv [])
         std::cerr << "Failed to initialize Panel Agent!\n";
         return -1;
     }
-
-    if (daemon)
-        scim_daemon ();
 
     // connect the configuration reload signal.
     _config->signal_connect_reload (slot (ui_config_reload_callback));


### PR DESCRIPTION
This fixes a deadlock in the GTK panel that appeared somewhat recently. Forking while multiple threads are active is generally asking for trouble; I assume the deadlock is the result of some recent internal change in GDK.

I gave the other SCIM programs a quick look and didn't spot any similar issues there. Only the GTK panel should be affected.